### PR TITLE
  .NET Standard dlls 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 .paket/paket.exe
 .paket/Paket.Restore.targets
+paket-files/paket.restore.cached
 tools/
 
 # User-specific files

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 
 ## Tools & Build Section
 
-.paket/
+.paket/paket.exe
+.paket/Paket.Restore.targets
 tools/
 
 # User-specific files

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 
 ## Tools & Build Section
 
-.paket/paket.exe
+.paket/
 tools/
 
 # User-specific files

--- a/buildPackages.bat
+++ b/buildPackages.bat
@@ -1,4 +1,4 @@
-set DXVersion=15.1
+set DXVersion=18.1
 set SymbolsFolder=c:\tmp\symbols
 set TargetNugetFolder=C:\tmp\Nuget
 set Localization=de;es;ja;ru

--- a/src/DXNugetPackageBuilder/DXNugetPackageBuilder.csproj
+++ b/src/DXNugetPackageBuilder/DXNugetPackageBuilder.csproj
@@ -66,8 +66,6 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="NugetAssemblyAnalyzer.cs" />
-    <Compile Include="NugetSpec.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="ProgramArguments.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/DXNugetPackageBuilder/DXNugetPackageBuilder.csproj
+++ b/src/DXNugetPackageBuilder/DXNugetPackageBuilder.csproj
@@ -76,7 +76,7 @@
     <None Include="paket.references" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
@@ -84,7 +84,7 @@
   </Target>
   -->
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1' Or $(TargetFrameworkVersion) == 'v4.7.2')">
       <ItemGroup>
         <Reference Include="Microsoft.Web.XmlTransform">
           <HintPath>..\..\packages\Microsoft.Web.Xdt\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
@@ -95,7 +95,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1'Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1' Or $(TargetFrameworkVersion) == 'v4.7.2')">
       <ItemGroup>
         <Reference Include="NuGet.Core">
           <HintPath>..\..\packages\NuGet.Core\lib\net40-Client\NuGet.Core.dll</HintPath>

--- a/src/DXNugetPackageBuilder/NugetAssemblyAnalyzer.cs
+++ b/src/DXNugetPackageBuilder/NugetAssemblyAnalyzer.cs
@@ -1,7 +1,0 @@
-﻿namespace DXNugetPackageBuilder
-{
-    public class NugetAssemblyAnalyzer
-    {
-         
-    }
-}

--- a/src/DXNugetPackageBuilder/NugetSpec.cs
+++ b/src/DXNugetPackageBuilder/NugetSpec.cs
@@ -1,7 +1,0 @@
-﻿namespace DXNugetPackageBuilder
-{
-    public class NugetSpec
-    {
-         
-    }
-}

--- a/src/DXNugetPackageBuilder/Program.cs
+++ b/src/DXNugetPackageBuilder/Program.cs
@@ -141,7 +141,6 @@ namespace DXNugetPackageBuilder
                         var assembly = Assembly.LoadFile(file); // Will load from GAC if components are installed from DevExpress Installer
                         logAction?.Invoke($"Assembly {assembly.Location} loaded !");
 
-
                         var pdbFile = Path.ChangeExtension(Path.GetFileName(file), "pdb");
 
                         pdbFile = Path.Combine(arguments.PdbDirectory, pdbFile);
@@ -254,7 +253,7 @@ namespace DXNugetPackageBuilder
                                 // .Net Standard version of Assembly.LoadFrom would work, by not accessing the GAC
                                 if(standardAssembly.Location.Contains("GAC_MSIL"))
                                 {
-                                    logExceptionAction(new FileLoadException("Trying to load a standard dll from the GAC. It won't work, the script shouldn't be run on computer where DevExpress Installer has been run! Copy the necessary components on a computer without DevExpress installed."));
+                                    logExceptionAction?.Invoke(new FileLoadException("Trying to load a standard dll from the GAC. It won't work, the script shouldn't be run on computer where DevExpress Installer has been run! Copy the necessary components on a computer without DevExpress installed."));
                                 }
 
                                 logAction?.Invoke("netstandard20 dependencies:");

--- a/src/DXNugetPackageBuilder/Program.cs
+++ b/src/DXNugetPackageBuilder/Program.cs
@@ -4,8 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Security.Policy;
-using System.Text;
+using System.Runtime.Versioning;
 using NuGet;
 
 namespace DXNugetPackageBuilder
@@ -22,40 +21,38 @@ namespace DXNugetPackageBuilder
                 return;
             }
 
-            var waringns = new List<Tuple<string, Exception>>();
+            var warnings = new List<Tuple<string, Exception>>();
             var success = new List<string>();
 
             if (!arguments.NugetPushOnly)
             {
-
                 BuildPackages(arguments, dependency =>
                 {
                     if (arguments.Verbose)
+                    {
                         Console.WriteLine("\t" + dependency);
+                    }
                 },
                     ex =>
                     {
                         var oldColor = Console.ForegroundColor;
                         Console.ForegroundColor = ConsoleColor.Red;
-                        Console.WriteLine(ex.ToString());
+                        Console.WriteLine(ex);
                         Console.ForegroundColor = oldColor;
                     },
-                    waringns.Add,
-                    ex =>
-                    {
-                        throw ex;
-                    },
+                    warnings.Add,
+                    ex => throw ex,
                     success.Add
                     );
 
-
-                if (waringns.Count > 0)
+                if (warnings.Count > 0)
                 {
+                    var oldColor = Console.ForegroundColor;
                     Console.ForegroundColor = ConsoleColor.Yellow;
 
-                    Console.WriteLine("{0} Warnigns occured", waringns.Count);
+                    Console.WriteLine($"{warnings.Count} Warnings occured");
 
-                    foreach (var warning in waringns)
+                    foreach (var warning in warnings)
                     {
                         Console.WriteLine(new string('-', Console.BufferWidth));
                         Console.WriteLine(warning.Item1);
@@ -63,6 +60,7 @@ namespace DXNugetPackageBuilder
 
                         Console.WriteLine(warning.Item2);
                     }
+                    Console.ForegroundColor = oldColor;
                 }
             }
 
@@ -88,13 +86,16 @@ namespace DXNugetPackageBuilder
             }
         }
 
-        private static void BuildPackages(ProgramArguments arguments, Action<string> logAction, Action<Exception> logExceptionAction, Action<Tuple<string, Exception>> logLoadAssemblyAction, Action<Exception> unexpectedExceptionAction, Action<string> successAction)
+        static void BuildPackages(ProgramArguments arguments, Action<string> logAction, Action<Exception> logExceptionAction, Action<Tuple<string, Exception>> logLoadAssemblyAction, Action<Exception> unexpectedExceptionAction, Action<string> successAction)
         {
             if (!Directory.Exists(arguments.SourceDirectory))
             {
-                logExceptionAction(new DirectoryNotFoundException($"{arguments.SourceDirectory} does not exists"));
+                logExceptionAction?.Invoke(new DirectoryNotFoundException($"{arguments.SourceDirectory} does not exists"));
                 return;
             }
+
+            // We assume that the Components\Bin has 2 subfolders : Framework for net40, Standard for netstandard20
+            var standardDirectory = Path.Combine(Directory.GetParent(arguments.SourceDirectory).FullName, "Standard");
 
             if (!Directory.Exists(arguments.OutputDirectory))
             {
@@ -106,15 +107,24 @@ namespace DXNugetPackageBuilder
                 Directory.CreateDirectory(arguments.PdbDirectory);
             }
 
-            foreach (var file in Directory.EnumerateFiles(arguments.SourceDirectory, "*.dll").Concat(Directory.EnumerateFiles(arguments.SourceDirectory, "*.exe")).Where(f => Path.GetFileNameWithoutExtension(f).StartsWith("DevExpress")))
+            // When downloading the pdbs from DevExpress, the pdb archive has a subfolder Standard that holds the netstandard20 pdbs
+            var standardPdbDirectory = Path.Combine(arguments.PdbDirectory, "Standard");
+
+            if (!Directory.Exists(standardPdbDirectory))
+            {
+                Directory.CreateDirectory(standardPdbDirectory);
+            }
+
+            foreach (var file in Directory.EnumerateFiles(arguments.SourceDirectory, "*.dll").Concat(Directory.EnumerateFiles(arguments.SourceDirectory, "*.exe")).Where(f => Path.GetFileNameWithoutExtension(f).StartsWith("DevExpress", StringComparison.Ordinal)))
             {
                 try
                 {
                     var packageName = Path.GetFileNameWithoutExtension(file);
 
-                    var package = new PackageBuilder();
-
-                    package.Description = "DevExpress " + packageName;
+                    var package = new PackageBuilder
+                    {
+                        Description = "DevExpress " + packageName
+                    };
                     package.Authors.Add("Developer Express Inc.");
                     package.IconUrl = new Uri("https://www.devexpress.com/favicon.ico?v=2");
                     package.Copyright = "2008-" + DateTime.Today.Year;
@@ -128,8 +138,9 @@ namespace DXNugetPackageBuilder
 
                     try
                     {
+                        var assembly = Assembly.LoadFile(file); // Will load from GAC if components are installed from DevExpress Installer
+                        logAction?.Invoke($"Assembly {assembly.Location} loaded !");
 
-                        var assembly = Assembly.LoadFile(file);
 
                         var pdbFile = Path.ChangeExtension(Path.GetFileName(file), "pdb");
 
@@ -166,7 +177,6 @@ namespace DXNugetPackageBuilder
                             });
                         }
 
-
                         var assemblyVersion = assembly.GetName().Version;
 
                         var dxVersion = ".v" + assemblyVersion.Major + "." + assemblyVersion.Minor;
@@ -179,50 +189,199 @@ namespace DXNugetPackageBuilder
                         }
 
                         if (packageName.Contains(dxVersion))
+                        {
                             packageName = packageName.Replace(dxVersion, string.Empty);
+                        }
 
                         var targetPackagePath = Path.Combine(arguments.OutputDirectory, packageName + "." + assemblyVersion.ToString(4) + ".nupkg");
 
                         if (File.Exists(targetPackagePath))
+                        {
                             File.Delete(targetPackagePath);
+                        }
 
                         package.Id = packageName;
                         package.Version = new SemanticVersion(assemblyVersion);
 
-                        var dependencies = new List<PackageDependency>();
-
-                        foreach (var refAssembly in assembly.GetReferencedAssemblies().Where(r => r.Name.StartsWith("DevExpress")))
+                        logAction?.Invoke("net40 dependencies:");
+                        // We only go for DevExpress dependencies - the rest should be only .NET Framework dependencies
+                        var dependencies = PullDependencies(arguments, logAction, package, assembly.GetReferencedAssemblies().Where(r => r.Name.StartsWith("DevExpress", StringComparison.Ordinal)), dxVersion);
+                        if (dependencies.Count == 0)
                         {
-                            logAction(refAssembly.Name);
+                            logAction?.Invoke($"No net40 dependencies!");
+                        }
 
-                            var refPackageId = refAssembly.Name;
+                        // We need to provide an explicit framework name, in case we have a netstandard20 version
+                        package.DependencySets.Add(new PackageDependencySet(new FrameworkName(".NETFramework, Version=4.0"), dependencies));
 
-                            if (refPackageId.Contains(dxVersion))
-                                refPackageId = refPackageId.Replace(dxVersion, string.Empty);
-
-
-                            var refAssemblyVersion = refAssembly.Version;
-
-                            var minVersion = new SemanticVersion(new Version(refAssemblyVersion.Major, refAssemblyVersion.Minor, refAssemblyVersion.Build));
-                            var maxVersion = new SemanticVersion(new Version(refAssemblyVersion.Major, refAssemblyVersion.Minor, refAssemblyVersion.Build + 1));
-
-                            var versionSpec = new VersionSpec { MinVersion = minVersion, MaxVersion = maxVersion, IsMinInclusive = true };
-
-                            var dependency = new PackageDependency(refPackageId, versionSpec);
-
-                            if (!arguments.Strict)
+                        // netstandard20 part - skipped if not standard folder is found next to the framework folder.
+                        // Only checks if we have a file of the same name in the standard folder, it does not create pure standard20 packages.
+                        if (Directory.Exists(standardDirectory))
+                        {
+                            var standardFile = Path.Combine(standardDirectory, Path.GetFileName(file));
+                            if (File.Exists(standardFile))
                             {
-                                var skippedDependencies = new Dictionary<string, string[]>();
+                                package.Files.Add(new PhysicalPackageFile
+                                {
+                                    SourcePath = standardFile,
+                                    TargetPath = "lib/netstandard20/" + Path.GetFileName(standardFile),
+                                });
 
-                                skippedDependencies["DevExpress.Persistent.Base"] = new[]
+                                // PDB Files retains the name, only the folder is different
+                                var standardPdbFile = Path.Combine(standardPdbDirectory, pdbFile);
+
+                                if (File.Exists(standardPdbFile))
+                                {
+                                    package.Files.Add(new PhysicalPackageFile
+                                    {
+                                        SourcePath = standardPdbFile,
+                                        TargetPath = "lib/netstandard20/" + Path.GetFileName(standardPdbFile),
+                                    });
+                                }
+
+                                // XML Files are identical for both targets
+                                if (File.Exists(xmlFile))
+                                {
+                                    package.Files.Add(new PhysicalPackageFile
+                                    {
+                                        SourcePath = xmlFile,
+                                        TargetPath = "lib/netstandard20/" + Path.GetFileName(xmlFile),
+                                    });
+                                }
+
+                                var standardAssembly = Assembly.LoadFile(standardFile);
+                                logAction?.Invoke($"Assembly {standardAssembly.Location} loaded !");
+                                // .Net Standard version of Assembly.LoadFrom would work, by not accessing the GAC
+                                if(standardAssembly.Location.Contains("GAC_MSIL"))
+                                {
+                                    logExceptionAction(new FileLoadException("Trying to load a standard dll from the GAC. It won't work, the script shouldn't be run on computer where DevExpress Installer has been run! Copy the necessary components on a computer without DevExpress installed."));
+                                }
+
+                                logAction?.Invoke("netstandard20 dependencies:");
+                                // We go for all dependencies, as all of them should be pull from NuGet packages
+                                var standardDependencies = PullDependencies(arguments, logAction, package, standardAssembly.GetReferencedAssemblies(), dxVersion);
+                                if (dependencies.Count == 0)
+                                {
+                                    logAction?.Invoke($"No netstandard dependencies!");
+                                }
+                                package.DependencySets.Add(new PackageDependencySet(new FrameworkName(".NETStandard, Version=2.0"), standardDependencies));
+                            }
+                        }
+
+                        CreateLocalization(file, package, arguments);
+
+                        using (var fs = new FileStream(targetPackagePath, FileMode.CreateNew, FileAccess.ReadWrite))
+                        {
+                            package.Save(fs);
+
+                            successAction?.Invoke(package.Id);
+                        }
+
+                        Console.WriteLine(packageName);
+                    }
+                    catch (Exception ex)
+                    {
+                        logExceptionAction?.Invoke(ex);
+                        logLoadAssemblyAction?.Invoke(Tuple.Create(package.Id, ex));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logExceptionAction?.Invoke(ex);
+                    unexpectedExceptionAction?.Invoke(ex);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Pulls the dependencies from an assembly - works for both net40 and netstandard20
+        /// </summary>
+        /// <param name="arguments">The arguments provided to the command line.</param>
+        /// <param name="logAction">The log action.</param>
+        /// <param name="package">The package builder.</param>
+        /// <param name="referencedAssemblies">The referenced assemblies from which we'll deduce the dependencies.</param>
+        /// <param name="dxVersion">The devExpress version currently built.</param>
+        /// <returns></returns>
+        static List<PackageDependency> PullDependencies(ProgramArguments arguments, Action<string> logAction, PackageBuilder package, IEnumerable<AssemblyName> referencedAssemblies, string dxVersion)
+        {
+            var dependencies = new List<PackageDependency>();
+
+            foreach (var refAssembly in referencedAssemblies)
+            {
+                logAction?.Invoke(refAssembly.Name + ": " + refAssembly.Version);
+
+                var refPackageId = refAssembly.Name;
+
+                if (refPackageId.StartsWith("DevExpress", StringComparison.Ordinal) && refPackageId.Contains(dxVersion))
+                {
+                    refPackageId = refPackageId.Replace(dxVersion, string.Empty);
+                }
+
+                var refAssemblyVersion = refAssembly.Version;
+
+                VersionSpec versionSpec;
+
+                if (refPackageId == "netstandard")
+                {
+                    // .NET Standard ugly part - The dll versions are not matching the packages
+                    // An alternative, would be to extract the versions from the csproj in the pdbs
+                    refPackageId = "NETStandard.Library";
+                    if (refAssemblyVersion.Major == 2 && refAssemblyVersion.Minor == 0 && refAssemblyVersion.Build <= 3)
+                    {
+                        versionSpec = new VersionSpec { MinVersion = new SemanticVersion("2.0.3"), IsMinInclusive = true };
+                        logAction?.Invoke("     Forced Version:" + versionSpec);
+                    }
+                }
+
+                if (refPackageId.StartsWith("DevExpress", StringComparison.Ordinal))
+                {
+                    var minVersion = new SemanticVersion(new Version(refAssemblyVersion.Major, refAssemblyVersion.Minor, refAssemblyVersion.Build));
+                    var maxVersion = new SemanticVersion(new Version(refAssemblyVersion.Major, refAssemblyVersion.Minor, refAssemblyVersion.Build + 1));
+                    versionSpec = new VersionSpec { MinVersion = minVersion, MaxVersion = maxVersion, IsMinInclusive = true };
+                }
+                else
+                {
+                    // .NET Standard ugly part - The dll versions are not matching the packages
+                    // An alternative, would be to extract the versions from the csproj in the pdbs
+                    if ((refPackageId == "System.Drawing.Common" || refPackageId == "System.CodeDom" || refPackageId == "System.Data.SqlClient" || refPackageId == "System.Configuration.ConfigurationManager")
+                        && refAssemblyVersion.Major == 4 && refAssemblyVersion.Minor <= 5)
+                    {
+                        versionSpec = new VersionSpec { MinVersion = new SemanticVersion("4.5.0"), IsMinInclusive = true };
+                        logAction?.Invoke("     Forced Version:" + versionSpec);
+                    }
+                    else if ((refPackageId == "System.ComponentModel.Annotations" || refPackageId == "System.ServiceModel.Primitives" || refPackageId == "System.ServiceModel.Http" || refPackageId == "System.Text.Encoding.CodePages")
+                        && refAssemblyVersion.Major == 4 && refAssemblyVersion.Minor <= 4)
+                    {
+                        versionSpec = new VersionSpec { MinVersion = new SemanticVersion("4.4.0"), IsMinInclusive = true };
+                        logAction?.Invoke("     Forced Version:" + versionSpec);
+                    }
+                    else if ((refPackageId == "System.Reflection.Emit" || refPackageId == "System.Reflection.Emit.Lightweight" || refPackageId == "System.Reflection.Emit.ILGeneration")
+                        && refAssemblyVersion.Major == 4 && refAssemblyVersion.Minor <= 3)
+                    {
+                        versionSpec = new VersionSpec { MinVersion = new SemanticVersion("4.3.0"), IsMinInclusive = true };
+                        logAction?.Invoke("     Forced Version:" + versionSpec);
+                    }
+                    else
+                    {
+                        versionSpec = new VersionSpec { MinVersion = new SemanticVersion(refAssemblyVersion), IsMinInclusive = true };
+                    }
+                }
+
+                var dependency = new PackageDependency(refPackageId, versionSpec);
+
+                if (!arguments.Strict)
+                {
+                    var skippedDependencies = new Dictionary<string, string[]>
+                    {
+                        ["DevExpress.Persistent.Base"] = new[]
                                 {
                                     "DevExpress.Utils",
                                     "DevExpress.XtraReports",
                                     "DevExpress.XtraReports.Extensions",
                                     "DevExpress.Printing.Core",
-                                };
+                                },
 
-                                skippedDependencies["DevExpress.Persistent.BaseImpl"] = new[]
+                        ["DevExpress.Persistent.BaseImpl"] = new[]
                                 {
                                     "DevExpress.Utils",
                                     "DevExpress.ExpressApp.ReportsV2",
@@ -230,9 +389,9 @@ namespace DXNugetPackageBuilder
                                     "DevExpress.XtraReports",
                                     "DevExpress.ExpressApp.ConditionalAppearance",
                                     "DevExpress.XtraScheduler.Core",
-                                };
+                                },
 
-                                skippedDependencies["DevExpress.Persistent.BaseImpl.EF"] = new[]
+                        ["DevExpress.Persistent.BaseImpl.EF"] = new[]
                                 {
                                     "DevExpress.Utils",
                                     "DevExpress.ExpressApp.Kpi",
@@ -244,57 +403,28 @@ namespace DXNugetPackageBuilder
                                     "DevExpress.XtraReports",
                                     "DevExpress.XtraScheduler.Core",
                                     "DevExpress.ExpressApp.Reports"
-                                };
-
-                                if (skippedDependencies.Keys.Any(id => package.Id.Equals(id, StringComparison.InvariantCultureIgnoreCase)))
-                                {
-                                    var skippedDependency = skippedDependencies[package.Id];
-
-                                    if (skippedDependency.Any(id => dependency.Id.Equals(id)))
-                                    {
-                                        logAction($"Skipping Dependency: {dependency.Id} for Package {package.Id} to avoid UI in Persistence");
-                                        continue;
-                                    }
                                 }
-                            }
+                    };
 
-                            dependencies.Add(dependency);
-
-                        }
-
-                        package.DependencySets.Add(new PackageDependencySet(null, dependencies));
-
-
-                        CreateLocalization(file, package, arguments);
-
-
-                        using (var fs = new FileStream(targetPackagePath, FileMode.CreateNew, FileAccess.ReadWrite))
-                        {
-                            package.Save(fs);
-
-                            successAction(package.Id);
-                        }
-
-                        Console.WriteLine(packageName);
-                    }
-                    catch (Exception ex)
+                    if (skippedDependencies.Keys.Any(id => package.Id.Equals(id, StringComparison.InvariantCultureIgnoreCase)))
                     {
-                        logExceptionAction(ex);
-                        logLoadAssemblyAction(Tuple.Create(package.Id, ex));
+                        var skippedDependency = skippedDependencies[package.Id];
+
+                        if (skippedDependency.Any(dependency.Id.Equals))
+                        {
+                            logAction?.Invoke($"Skipping Dependency: {dependency.Id} for Package {package.Id} to avoid UI in Persistence");
+                            continue;
+                        }
                     }
                 }
-                catch (Exception ex)
-                {
-                    logExceptionAction(ex);
-                    unexpectedExceptionAction(ex);
-                }
+
+                dependencies.Add(dependency);
             }
+            return dependencies;
         }
 
-
-        private static void CreateLocalization(string file, PackageBuilder resourcePackage, ProgramArguments arguments)
+        static void CreateLocalization(string file, PackageBuilder resourcePackage, ProgramArguments arguments)
         {
-            var assemblyFileName = Path.GetFileName(file);
             var resourceFileName = Path.GetFileName(Path.ChangeExtension(file, "resources.dll"));
 
             foreach (var lang in arguments.LanguagesAsArray)
@@ -322,11 +452,11 @@ namespace DXNugetPackageBuilder
             }
         }
 
-        private static void PushPackages(ProgramArguments arguments)
+        static void PushPackages(ProgramArguments arguments)
         {
             var packages = Directory.GetFiles(arguments.OutputDirectory, "*.nupkg").ToList();
 
-            Console.WriteLine("Pushing {0} packages to " + arguments.NugetSource, packages.Count());
+            Console.WriteLine("Pushing {0} packages to " + arguments.NugetSource, packages.Count);
 
             foreach (var package in packages)
             {
@@ -336,12 +466,14 @@ namespace DXNugetPackageBuilder
 
                     using (var process = new Process())
                     {
-                        process.StartInfo = new ProcessStartInfo("nuget.exe", string.Format("push {0} -Source {1} -ApiKey {2}", packageName, arguments.NugetSource, arguments.NugetApiKey));
-                        process.StartInfo.CreateNoWindow = true;
-                        process.StartInfo.ErrorDialog = false;
-                        process.StartInfo.RedirectStandardError = true;
-                        process.StartInfo.RedirectStandardOutput = true;
-                        process.StartInfo.UseShellExecute = false;
+                        process.StartInfo = new ProcessStartInfo("nuget.exe", $"push {packageName} -Source {arguments.NugetSource} -ApiKey {arguments.NugetApiKey}")
+                        {
+                            CreateNoWindow = true,
+                            ErrorDialog = false,
+                            RedirectStandardError = true,
+                            RedirectStandardOutput = true,
+                            UseShellExecute = false
+                        };
 
                         process.OutputDataReceived += (sender, args) => Console.WriteLine(args.Data);
                         process.ErrorDataReceived += (sender, args) => Console.WriteLine(args.Data);
@@ -360,7 +492,6 @@ namespace DXNugetPackageBuilder
                     Console.WriteLine(ex);
                     Console.ReadKey();
                 }
-
             }
         }
     }

--- a/src/DXNugetPackageBuilder/Program.cs
+++ b/src/DXNugetPackageBuilder/Program.cs
@@ -426,7 +426,7 @@ namespace DXNugetPackageBuilder
         {
             var resourceFileName = Path.GetFileName(Path.ChangeExtension(file, "resources.dll"));
 
-            foreach (var lang in arguments.LanguagesAsArray)
+            foreach (var lang in arguments.LanguagesEnumerable)
             {
                 var localizedAssemblyPath = Path.Combine(arguments.SourceDirectory, lang, resourceFileName);
                 if (File.Exists(localizedAssemblyPath))

--- a/src/DXNugetPackageBuilder/ProgramArguments.cs
+++ b/src/DXNugetPackageBuilder/ProgramArguments.cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel;
 using Ookii.CommandLine;
-using System;
 
 namespace DXNugetPackageBuilder
 {
@@ -41,8 +40,10 @@ namespace DXNugetPackageBuilder
         {
             get
             {
-                if(String.IsNullOrEmpty(Languages))
+                if(string.IsNullOrEmpty(Languages))
+                {
                     return new string[] { };
+                }
 
                 return Languages.Split(';');
             }
@@ -67,7 +68,9 @@ namespace DXNugetPackageBuilder
                 // The Parse function returns null only when the ArgumentParsed event handler cancelled parsing.
                 var result = (ProgramArguments)parser.Parse(args);
                 if(result != null)
+                {
                     return result;
+                }
             }
             catch(CommandLineArgumentException ex)
             {
@@ -95,7 +98,9 @@ namespace DXNugetPackageBuilder
             // Try it: just call the sample with "CommandLineSampleCS.exe foo bar -Help", which will print usage even though both the Source and Destination
             // arguments are supplied.
             if(e.Argument.ArgumentName == "Help") // The name is always Help even if the alias was used to specify the argument
+            {
                 e.Cancel = true;
+            }
         }
     }
 }

--- a/src/DXNugetPackageBuilder/ProgramArguments.cs
+++ b/src/DXNugetPackageBuilder/ProgramArguments.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using Ookii.CommandLine;
 
 namespace DXNugetPackageBuilder
@@ -35,15 +36,14 @@ namespace DXNugetPackageBuilder
         [CommandLineArgument(IsRequired = false, DefaultValue = false)]
         public bool Strict { get; set; }
 
-        public IEnumerable<string> LanguagesAsArray
+        public IEnumerable<string> LanguagesEnumerable
         {
             get
             {
-                if(string.IsNullOrEmpty(Languages))
+                if (string.IsNullOrEmpty(Languages))
                 {
-                    return new string[] { };
+                    return Enumerable.Empty<string>();
                 }
-
                 return Languages.Split(';');
             }
         }
@@ -66,15 +66,15 @@ namespace DXNugetPackageBuilder
             {
                 // The Parse function returns null only when the ArgumentParsed event handler cancelled parsing.
                 var result = (ProgramArguments)parser.Parse(args);
-                if(result != null)
+                if (result != null)
                 {
                     return result;
                 }
             }
-            catch(CommandLineArgumentException ex)
+            catch (CommandLineArgumentException ex)
             {
                 // We use the LineWrappingTextWriter to neatly wrap console output.
-                using(var writer = LineWrappingTextWriter.ForConsoleError())
+                using (var writer = LineWrappingTextWriter.ForConsoleError())
                 {
                     // Tell the user what went wrong.
                     writer.WriteLine(ex.Message);

--- a/src/DXNugetPackageBuilder/ProgramArguments.cs
+++ b/src/DXNugetPackageBuilder/ProgramArguments.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
 using Ookii.CommandLine;
 
 namespace DXNugetPackageBuilder
@@ -6,7 +7,6 @@ namespace DXNugetPackageBuilder
     [Description("Builds Nuget Packages from DevExpress-Assemblies")]
     public class ProgramArguments
     {
-
         [CommandLineArgument(Position = 0, IsRequired = true), Description("The directory where the DevExpress Assemblies live")]
         public string SourceDirectory { get; set; }
 
@@ -32,11 +32,10 @@ namespace DXNugetPackageBuilder
         [CommandLineArgument(IsRequired = false, DefaultValue = false)]
         public bool UseAssemblyFileVersion { get; set; }
 
-
         [CommandLineArgument(IsRequired = false, DefaultValue = false)]
         public bool Strict { get; set; }
 
-        public string[] LanguagesAsArray
+        public IEnumerable<string> LanguagesAsArray
         {
             get
             {
@@ -85,19 +84,19 @@ namespace DXNugetPackageBuilder
 
             // If we got here, we should print usage information to the console.
             // By default, aliases and default values are not included in the usage descriptions; for this sample, I do want to include them.
-            var options = new WriteUsageOptions() { IncludeDefaultValueInDescription = true, IncludeAliasInDescription = true };
+            var options = new WriteUsageOptions { IncludeDefaultValueInDescription = true, IncludeAliasInDescription = true };
             // WriteUsageToConsole automatically uses a LineWrappingTextWriter to properly word-wrap the text.
             parser.WriteUsageToConsole(options);
             return null;
         }
 
-        private static void CommandLineParser_ArgumentParsed(object sender, ArgumentParsedEventArgs e)
+        static void CommandLineParser_ArgumentParsed(object sender, ArgumentParsedEventArgs e)
         {
             // When the -Help argument (or -? using its alias) is specified, parsing is immediately cancelled. That way, CommandLineParser.Parse will
             // return null, and the Create method will display usage even if the correct number of positional arguments was supplied.
             // Try it: just call the sample with "CommandLineSampleCS.exe foo bar -Help", which will print usage even though both the Source and Destination
             // arguments are supplied.
-            if(e.Argument.ArgumentName == "Help") // The name is always Help even if the alias was used to specify the argument
+            if (e.Argument.ArgumentName == "Help") // The name is always Help even if the alias was used to specify the argument
             {
                 e.Cancel = true;
             }


### PR DESCRIPTION
fix #3 

This works but there could be improvements. The main issue is the fact that it won't work for the standard part on a machine that has DevExpress installed throught the installer, as the installer would register the Framework dlls in the GAC, and no matter the way you try to load the standard ones from the files, the Framework dlls will be loaded from the GAC instead anyway.
Migrating the program itself to .net core might solve the issue as the assembly loader from .net core doesn't seem to care for the GAC for .net standard dll. This would be a major change for the project (shoud we use PackageReference instead of Paket for example?), I was not comfortable changing it with this fix, unless you think it's a good idea.

The other issue is the versionning mismatch between the dll dependencies, and the nuget package that come from System / Microsoft. Don't think there's a way to find an exact version of the package used, except from reading the csproj from the pdbs. Which would be another major change for the project. Considerinf DevExpress doesn't rely on many of those dlls, I hardcoded the minimal versions needed for each packages.