### PR TITLE
Migration to .net core to avoid the GAC

### DIFF
--- a/DXNugetPackageBuilder.sln
+++ b/DXNugetPackageBuilder.sln
@@ -18,8 +18,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".git", ".git", "{8D8D9A31-3
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A1CCACDA-7EEF-410F-AAC5-C42189BAD40E}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DXNugetPackageBuilder", "src\DXNugetPackageBuilder\DXNugetPackageBuilder.csproj", "{5B7C83A1-179C-4805-9727-69E6C7024EF0}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".proj", ".proj", "{A02A4759-44C3-4E41-B794-EAD39F14A0DD}"
 	ProjectSection(SolutionItems) = preProject
 		buildPackages.bat = buildPackages.bat
@@ -27,28 +25,24 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".proj", ".proj", "{A02A4759
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DXNugetPackageBuilder", "src\DXNugetPackageBuilder\DXNugetPackageBuilder.csproj", "{6D71707B-957E-4580-82D7-5FA28DD63BB1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{5B7C83A1-179C-4805-9727-69E6C7024EF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5B7C83A1-179C-4805-9727-69E6C7024EF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5B7C83A1-179C-4805-9727-69E6C7024EF0}.Debug|x86.ActiveCfg = Debug|x86
-		{5B7C83A1-179C-4805-9727-69E6C7024EF0}.Debug|x86.Build.0 = Debug|x86
-		{5B7C83A1-179C-4805-9727-69E6C7024EF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5B7C83A1-179C-4805-9727-69E6C7024EF0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5B7C83A1-179C-4805-9727-69E6C7024EF0}.Release|x86.ActiveCfg = Release|x86
-		{5B7C83A1-179C-4805-9727-69E6C7024EF0}.Release|x86.Build.0 = Release|x86
+		{6D71707B-957E-4580-82D7-5FA28DD63BB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D71707B-957E-4580-82D7-5FA28DD63BB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D71707B-957E-4580-82D7-5FA28DD63BB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D71707B-957E-4580-82D7-5FA28DD63BB1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{5B7C83A1-179C-4805-9727-69E6C7024EF0} = {A1CCACDA-7EEF-410F-AAC5-C42189BAD40E}
+		{6D71707B-957E-4580-82D7-5FA28DD63BB1} = {A1CCACDA-7EEF-410F-AAC5-C42189BAD40E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6D3B94D7-622F-410D-83B7-7BAC4E0A20D0}

--- a/build.cake
+++ b/build.cake
@@ -5,18 +5,18 @@ var sln = "./DXNugetPackageBuilder.sln";
 Task("Clean")
 	.Does(() =>
 {
-	DeleteDirectories(GetDirectories("./src/**/obj"), new DeleteDirectorySettings 
+	DeleteDirectories(GetDirectories("./src/**/obj"), new DeleteDirectorySettings
 	{
 		Recursive = true
 	});
-	DeleteDirectories(GetDirectories("./src/**/bin"), new DeleteDirectorySettings 
+	DeleteDirectories(GetDirectories("./src/**/bin"), new DeleteDirectorySettings
 	{
 		Recursive = true
 	});
 });
 
 Task("Copy-NuGet")
-	.Does(() => 
+	.Does(() =>
 {
 	CreateDirectory("./src/DXNugetPackageBuilder/bin/Debug/net45");
 	CopyFileToDirectory("./tools/nuget.exe", "./src/DXNugetPackageBuilder/bin/Debug/net45");
@@ -29,7 +29,7 @@ Task("Build")
 	.IsDependentOn("Clean")
 	.IsDependentOn("Restore")
 	.IsDependentOn("Copy-NuGet")
-	.Does(() => DotNetBuild(sln));
+	.Does(() => MSBuild(sln));
 
 
 Task("Default")

--- a/buildPackages.bat
+++ b/buildPackages.bat
@@ -9,14 +9,15 @@ REM set NugetApiKey=-NugetApiKey Your-Api-Key-Goes-Here
 set NugetPush=
 REM set NugetPush=-NugetPush
 
+REM Add "-Verbose" for verbosity
+Powershell.exe -executionpolicy remotesigned -File build.ps1
 
-Powershell.exe -executionpolicy remotesigned -File  build.ps1
-
-set Builder=src\DXNugetPackageBuilder\bin\Debug\net45\DXNugetPackageBuilder.exe
+set Builder=src\DXNugetPackageBuilder\bin\Debug\netcoreapp2.1\win-x64\DXNugetPackageBuilder.exe
 
 %Builder% "C:\Program Files (x86)\DevExpress %DXVersion%\DevExpressCodedUIExtensions\Tools" %SymbolsFolder% %TargetNugetFolder% %Localization% %NugetServer% %NugetApiKey% %NugetPush%
 
 %Builder% "C:\Program Files (x86)\DevExpress %DXVersion%\Components\Tools\eXpressAppFramework\Model Editor" %SymbolsFolder% %TargetNugetFolder% %Localization% %NugetServer% %NugetApiKey% %NugetPush%
 
+REM Add "-Verbose" for verbosity
 %Builder% "C:\Program Files (x86)\DevExpress %DXVersion%\Components\Bin\Framework" %SymbolsFolder% %TargetNugetFolder% %Localization% %NugetServer% %NugetApiKey% %NugetPush%
 

--- a/src/DXNugetPackageBuilder/DXNugetPackageBuilder.csproj
+++ b/src/DXNugetPackageBuilder/DXNugetPackageBuilder.csproj
@@ -1,19 +1,18 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
-    <Platforms>AnyCPU;x86</Platforms>
     <OutputType>Exe</OutputType>
-    <AssemblyTitle>DXNugetPackageBuilder</AssemblyTitle>
-    <Company></Company>
-    <Product>DXNugetPackageBuilder</Product>
-    <Description></Description>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <StartupObject>DXNugetPackageBuilder.Program</StartupObject>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <Copyright>Copyright © Manuel Grundner 2014</Copyright>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
+    <Authors>Manuel Grundner</Authors>
+    <Company>Manuel Grundner</Company>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="NuGet.Core" Version="2.14.0" />
-    <PackageReference Include="Ookii.CommandLine" Version="2.2.0" />
-  </ItemGroup> 
+    <PackageReference Include="NuGet.Packaging" Version="4.8.0" />
+    <PackageReference Include="Ookii.CommandLine" Version="3.0.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- fix cake warning
- change build path
- comments for verbosity (hard for me to remember the right syntax every time :P)
- migration of the project to .net core 2.1 / winx64 (have to choose a platform to have an exe)
- upgraded dependencies:
  - ookii.commandline: https://github.com/SvenGroot/ookii.commandline/pull/1
  - Nuget.Core: using the new packages that are compatible with .NET Core, changed the code accordingly

see #3 